### PR TITLE
FIX regex Patern

### DIFF
--- a/setup/etc/fail2ban/filter.d/issabel-gui.conf
+++ b/setup/etc/fail2ban/filter.d/issabel-gui.conf
@@ -15,7 +15,7 @@ __pid_re = (?:\[\d+\])
 
 iso8601 = \d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+[+-]\d{4}
 
-failregex = ^(%(__prefix_line)s|\[\]\s*)LOGIN ([^:]*): Authentication Failure to Web Interface login. Failed password for admin from <HOST>.$
+failregex = ^(%(__prefix_line)s|\[\]\s*)LOGIN ([^:]*): Authentication Failure to Web Interface login. Failed ([^:]*) for ([^:]*) from <HOST>.$
 
 ignoreregex =
 


### PR DESCRIPTION
//spanish//

git push origin 
el patron de log, solo es compatible con el usuario admin, sin contar los demas usuarios que podrian tener, y tambien sin contar el tipo de autenticacion como el "two factor code", por ejemplo

^(%(__prefix_line)s|\[\]\s*)LOGIN ([^:]*): Authentication Failure to Web Interface login. Failed password for admin from <HOST>.$
 el patron no es compatible con los demas usuarios que no sean admin, ni con los demas tipos de autenticacion
 
[Aug 30 02:05:07] LOGIN issabel: Authentication Failure to Web Interface login. Failed password for issabel from 190.236.76.70.
[Aug 30 02:06:21] LOGIN issabel: Authentication Failure to Web Interface login. Failed two factor code for issabel from 190.236.76.7

solo es compatible con usuario admin


[Aug 30 02:05:07] LOGIN admin: Authentication Failure to Web Interface login. Failed password for admin from 190.236.76.70.